### PR TITLE
Dockerize to build zookeeper archive.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM debian:jessie
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        openjdk-7-jdk ant \
+        build-essential libcppunit-dev python-setuptools libtool autoconf python-dev automake
+
+ADD . /arcus-zookeeper
+WORKDIR /arcus-zookeeper
+
+RUN ant tar
+
+CMD ["bash"]


### PR DESCRIPTION
Add Dockerfile to build modified zookeeper 3.4.5 regardless of platforms.

To build zookeeper (it tooks long time):

``` bash
$ docker build -t cs494/arcus-zookeeper-build .
```

After building, the archive could be extracted:

``` bash
$ docker run --name arcus-zookeeper-build cs494/arcus-zookeeper-build # instantiate container
$ docker cp arcus-zookeeper-build:/arcus-zookeeper/build/zookeeper-3.4.5.tar.gz .
```

This docker image is just for building. To run it, refer to [this repository](https://github.com/ducky-hong/docker-arcus-zookeeper).
