### PR TITLE
Fix build.xml: support for JDK >= 1.9

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -30,8 +30,8 @@
     <property name="revision.properties" value="revision.properties" />
     <property file="${basedir}/src/java/${revision.properties}" />
     
-    <property name="javac.target" value="1.5" />
-    <property name="javac.source" value="1.5" />
+    <property name="javac.target" value="1.6" />
+    <property name="javac.source" value="1.6" />
 
     <property name="src.dir" value="${basedir}/src" />
     <property name="java.src.dir" value="${src.dir}/java/main" />


### PR DESCRIPTION
이슈: openjdk 최신버전 (>= 1.9) 에서 arcus가 build 되지 않는 현상
빌드 환경: a docker container from ubuntu:lastest image (Docker 17.03.1-ce, build c6d412e)
```
# uname -a
Linux 227f9156bfa5 4.9.27-moby #1 SMP Thu May 11 04:01:18 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux
```

openjdk-1.9-jdk 가 설치된 환경에서 arcus를 build 할 시:
```
#./build.sh
ARCUS BUILD PROCESS: START
--------------------------
Working directory is /opt/arcus.
Detailed build log is recorded to scripts/build.log.
--------------------------
[git submodule init] .. SUCCEED
[git submodule update] .. SUCCEED
[server/config/autorun.sh] .. SUCCEED
[clients/c/config/autorun.sh] .. SUCCEED
[zookeeper/ant clean compile_jute bin-package] .. START
Error has occured. /opt/arcus/scripts/etc/autorun.sh has failed.
Error has occured. ./build.sh has failed.
Check /opt/arcus/scripts/build.log
```

build.log 확인 시:
```
Working directory is /opt/arcus.
/opt/arcus /opt/arcus/scripts
Submodule 'clients/c' (https://github.com/naver/arcus-c-client.git) registered for path 'clients/c'
Submodule 'clients/java' (https://github.com/naver/arcus-java-client.git) registered for path 'clients/java'
Submodule 'server' (https://github.com/naver/arcus-memcached.git) registered for path 'server'
Submodule 'zookeeper' (https://github.com/naver/arcus-zookeeper.git) registered for path 'zookeeper'

...

jute:
    [javac] Compiling 39 source files to /opt/arcus/zookeeper/build/classes
    [javac] warning: [options] bootstrap class path not set in conjunction with -source 1.5
    [javac] error: Source option 1.5 is no longer supported. Use 1.6 or later.
    [javac] error: Target option 1.5 is no longer supported. Use 1.6 or later.

BUILD FAILED
/opt/arcus/zookeeper/build.xml:240: Compile failed; see the compiler error output for details.

Total time: 1 second
```

이는 jdk >= 1.9 이후로 1.5 버전으로의 컴파일 옵션이 더 이상 지원되지 않기 때문에 발생한 에러로 보여집니다: [관련 링크](http://openjdk.java.net/jeps/182).

`arcus-zookeeper/build.xml` 에서 컴파일 옵션을 수정해주면 문제 없이 빌드되는 것을 확인했습니다.

Compatibility issue를 최소화하기 위해, 1.5 -> 1.6 으로 컴파일 버전을 한 단계만 올렸습니다. 
