### PR TITLE
Suppress unimportant automake warnings

### DIFF
--- a/src/c/configure.ac
+++ b/src/c/configure.ac
@@ -22,7 +22,7 @@ DX_PS_FEATURE(OFF)
 DX_INIT_DOXYGEN([zookeeper],[c-doc.Doxyfile],[docs])
 
 # initialize automake
-AM_INIT_AUTOMAKE([-Wall foreign])
+AM_INIT_AUTOMAKE([-Wall foreign subdir-objects -Wno-portability])
 AC_CONFIG_HEADER([config.h])
 
 # Checks for programs.


### PR DESCRIPTION
## Environment ##
Ubuntu 17.04 x86_64
GNU Autoconf 2.69
GNU Automake 1.15

## Issue ##
Automake의 버전이 올라감에 따라 build 과정에서 다양한 warning이 발생합니다.
Arcus는 Linux 환경에서 동작하므로 이들을 무시하도록 하였습니다.
```
$ autoreconf -if
...
Makefile.am:70: warning: wildcard ${srcdir}/tests/*.cc: non-POSIX variable name
Makefile.am:70: (probably a GNU make extension)
...
Makefile.am:13: warning: source file 'src/hashtable/hashtable_itr.c' is in a subdirectory,
Makefile.am:13: but option 'subdir-objects' is disabled
automake: warning: possible forward-incompatibility.
automake: At least a source file is in a subdirectory, but the 'subdir-objects'
automake: automake option hasn't been enabled.  For now, the corresponding output
automake: object file(s) will be placed in the top-level directory.  However,
automake: this behaviour will change in future Automake versions: they will
automake: unconditionally cause object files to be placed in the same subdirectory
automake: of the corresponding sources.
automake: You are advised to start using 'subdir-objects' option throughout your
automake: project, to avoid future incompatibilities.
...
/usr/share/automake-1.15/am/ltlibrary.am: warning: 'libhashtable.la': linking libtool libraries using a non-POSIX
/usr/share/automake-1.15/am/ltlibrary.am: archiver requires 'AM_PROG_AR' in 'configure.ac'
Makefile.am:16:   while processing Libtool library 'libhashtable.la'
...
```