### PR TITLE
Change maven central repository url.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -100,7 +100,7 @@
 
     <property name="ivy.version" value="2.2.0"/>
     <property name="ivy.url"
-              value="http://repo2.maven.org/maven2/org/apache/ivy/ivy" />
+              value="https://repo1.maven.org/maven2/org/apache/ivy/ivy" />
     <property name="ivy.home" value="${user.home}/.ant" />
     <property name="ivy.lib" value="${build.dir}/lib"/>
     <property name="ivy.package.lib" value="${build.dir}/package/lib"/>

--- a/ivysettings.xml
+++ b/ivysettings.xml
@@ -18,7 +18,7 @@
 -->
 
   <property name="repo.maven.org"
-    value="http://repo1.maven.org/maven2/" override="false"/>
+    value="https://repo1.maven.org/maven2/" override="false"/>
   <property name="repo.jboss.org"
     value="http://repository.jboss.org/nexus/content/groups/public/" override="false"/>
   <property name="repo.sun.org"

--- a/src/contrib/build-contrib.xml
+++ b/src/contrib/build-contrib.xml
@@ -43,7 +43,7 @@
 
   <property name="ivy.version" value="2.2.0"/>
   <property name="ivy.url"
-            value="http://repo2.maven.org/maven2/org/apache/ivy/ivy" />
+            value="https://repo1.maven.org/maven2/org/apache/ivy/ivy" />
   <property name="ivy.home" value="${user.home}/.ant" />
   <property name="ivy.lib" value="${build.dir}/lib"/>
   <property name="ivy.test.lib" value="${build.test}/lib"/>


### PR DESCRIPTION
현재 zookeeper 빌드시 maven central repository에 접근 불가하여 ivy 다운로드 실패합니다.
언제부터 url이 바뀌었는지 모르겠지만, https://mvnrepository.com/repos/central 에서 확인하여 url을 바꾸었습니다. 

arcus bulid
```
ARCUS BUILD PROCESS: START
--------------------------
Working directory is /home/suhwan/arcus.
Detailed build log is recorded to scripts/build.log.
--------------------------
[git submodule init] .. SUCCEED
[git submodule update] .. SUCCEED
[server/config/autorun.sh] .. SUCCEED
[clients/c/config/autorun.sh] .. SUCCEED
[zookeeper/ant clean compile_jute bin-package] .. START^Ccd
Error has occurred. /home/suhwan/arcus/scripts/etc/autorun.sh has failed.
```

zookeeper 폴더에서 ant 수동 실행
```
Buildfile: build.xml

init:
 + s/c/build-contrib.xml
    [mkdir] Created dir: /home/suhwan/arcus-zookeeper/build/classes
    [mkdir] Created dir: /home/suhwan/arcus-zookeeper/build/lib
    [mkdir] Created dir: /home/suhwan/arcus-zookeeper/build/package/lib
    [mkdir] Created dir: /home/suhwan/arcus-zookeeper/build/test/lib

ivy-download:
      [get] Getting: http://repo2.maven.org/maven2/org/apache/ivy/ivy/2.2.0/ivy-2.2.0.jar
      [get] To: /home/suhwan/arcus-zookeeper/src/java/lib/ivy-2.2.0.jar
      [get] Error getting http://repo2.maven.org/maven2/org/apache/ivy/ivy/2.2.0/ivy-2.2.0.jar to /home/suhwan/arcus-zookeeper/src/java/lib/ivy-2.2.0.jar

BUILD FAILED
java.net.UnknownHostException: repo2.maven.org
	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:178)
        ...
```

@hyjun328, @jhpark816 리뷰 부탁드립니다.
