### PR TITLE
Add README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+This is a branch off of ZooKeeper release 3.4.6.  We have made some minor 
+changes to the C client library (src/c).  So, we package that and distribute
+it along with arcus-memcached and arcus-c-client.  They rely on the modified library.
+
+Github project page:
+https://github.com/naver/arcus
+
+## Build C library on Linux
+
+In the top directory, run the following to generate necessary headers and
+scripts.  Then wrap the whole C library directory in a tarball and distribute
+that file.
+
+    ant compile_jute
+    cd src/c
+    autoreconf -if
+
+Make sure to install ant, cppunit, and cppunit-devel before running the above.
+`autoreconf` generates configure script.
+
+    ./configure --prefix=/path/to/arcus-directory
+    make
+    make install
+
+## Build Server and Java library on Linux
+
+In the top directory, run the following to build.
+
+    ant -f build.xml
+
+## Arcus Contributors
+
+The following people at NAVER have contributed to the Arcus specific
+modifications to the C client library.
+
+Hoonmin Kim (harebox) <harebox@gmail.com>  
+HyongYoub Kim


### PR DESCRIPTION
README.md 추가를 위한 PR 입니다.
기존 README 에서는 ZooKeeper C client library build에 관련된 설명만 되어있어서
기존 설명대로 빌드를 진행하면 ZooKeeper Server는 build가 되지 않았습니다.
`ant -f build.xml`을 통해 Server도 build할 수 있도록 설명을 추가 했습니다.

@jhpark816 
확인 요청 드립니다.