### PR TITLE
C library: support ZOO_LOG macros for backward compatibility

### DIFF
--- a/zookeeper-client/zookeeper-client-c/include/zookeeper_log.h
+++ b/zookeeper-client/zookeeper-client-c/include/zookeeper_log.h
@@ -43,30 +43,17 @@ ZOOAPI void log_message(log_callback_fn callback, ZooLogLevel curLevel,
 
 FILE* zoo_get_log_stream();
 
-/* FIXME
- * because it is used by the arcus-c-client,
- * it must be fix to ensure that support backward compatibility.
- */
+/* ZOO_LOG macros are used in arcus-c-client */
 #define ZOO_LOG_ERROR(x) if(logLevel>=ZOO_LOG_LEVEL_ERROR) \
-    log_message(ZOO_LOG_LEVEL_ERROR,__LINE__,__func__,format_log_message x)
+    zoo_log_message(ZOO_LOG_LEVEL_ERROR, __LINE__, __func__, format_log_message x)
 #define ZOO_LOG_WARN(x) if(logLevel>=ZOO_LOG_LEVEL_WARN) \
-    log_message(ZOO_LOG_LEVEL_WARN,__LINE__,__func__,format_log_message x)
+    zoo_log_message(ZOO_LOG_LEVEL_WARN, __LINE__, __func__, format_log_message x)
 #define ZOO_LOG_INFO(x) if(logLevel>=ZOO_LOG_LEVEL_INFO) \
-    log_message(ZOO_LOG_LEVEL_INFO,__LINE__,__func__,format_log_message x)
+    zoo_log_message(ZOO_LOG_LEVEL_INFO, __LINE__, __func__, format_log_message x)
 #define ZOO_LOG_DEBUG(x) if(logLevel==ZOO_LOG_LEVEL_DEBUG) \
-    log_message(ZOO_LOG_LEVEL_DEBUG,__LINE__,__func__,format_log_message x)
+    zoo_log_message(ZOO_LOG_LEVEL_DEBUG, __LINE__, __func__, format_log_message x)
 
-/* LOG_ is common naming.  So, when compiling a client program, prefix these
- * macros with ZOO_ to avoid conflicts.
- */
-#ifndef ZOOKEEPER_C_CLIENT
-#define LOG_ERROR  ZOO_LOG_ERROR
-#define LOG_WARN   ZOO_LOG_WARN
-#define LOG_INFO   ZOO_LOG_INFO
-#define LOG_DEBUG  ZOO_LOG_DEBUG
-#endif
-
-ZOOAPI void log_message(ZooLogLevel curLevel, int line,const char* funcName,
+ZOOAPI void zoo_log_message(ZooLogLevel curLevel, int line, const char* funcName,
     const char* message);
 
 ZOOAPI const char* format_log_message(const char* format,...);

--- a/zookeeper-client/zookeeper-client-c/src/zk_adaptor.h
+++ b/zookeeper-client/zookeeper-client-c/src/zk_adaptor.h
@@ -305,8 +305,8 @@ char* sub_string(zhandle_t *zh, const char* server_path);
 void free_duplicate_path(const char* free_path, const char* path);
 int zoo_lock_auth(zhandle_t *zh);
 int zoo_unlock_auth(zhandle_t *zh);
-void zoo_lock_new_addrs(zhandle_t *zh);
-void zoo_unlock_new_addrs(zhandle_t *zh);
+int zoo_lock_new_addrs(zhandle_t *zh);
+int zoo_unlock_new_addrs(zhandle_t *zh);
 
 // ensemble reconfigure access guards
 int lock_reconfig(struct _zhandle *zh);

--- a/zookeeper-client/zookeeper-client-c/src/zk_log.c
+++ b/zookeeper-client/zookeeper-client-c/src/zk_log.c
@@ -196,8 +196,11 @@ void log_message(log_callback_fn callback, ZooLogLevel curLevel,
     if(enableSyslog && logLevel >= curLevel) {
         static const char* sysDbgLevelStr[]={"INVALID","ERROR","WARN",
                                              "INFO","DEBUG"};
+        va_start(va,format);
+        vsnprintf(buf, FORMAT_LOG_BUF_SIZE-1, format, va);
+        va_end(va);
         syslog(map_syslog_priority(curLevel), "zookeeper[%s@%s@%d] %s",
-               sysDbgLevelStr[curLevel],funcName,line,message);
+               sysDbgLevelStr[curLevel], funcName, line, buf);
         return;
     }
 
@@ -232,6 +235,64 @@ void log_message(log_callback_fn callback, ZooLogLevel curLevel,
         fprintf(zoo_get_log_stream(), "%s\n", buf);
         fflush(zoo_get_log_stream());
     }
+}
+
+void zoo_log_message(ZooLogLevel curLevel,int line,const char* funcName,
+    const char* message)
+{
+    static const char* dbgLevelStr[]={"ZOO_INVALID","ZOO_ERROR","ZOO_WARN",
+            "ZOO_INFO","ZOO_DEBUG"};
+    static pid_t pid=0;
+#ifdef THREADED
+    unsigned long int tid = 0;
+#endif
+#ifdef WIN32
+    char timebuf [TIME_NOW_BUF_SIZE];
+    const char* time = time_now(timebuf);
+#else
+    const char* time = time_now(get_time_buffer());
+#endif
+
+    if(pid==0)
+    {
+        pid=getpid();
+    }
+
+    if(enableSyslog && logLevel >= curLevel) {
+        static const char* sysDbgLevelStr[]={"INVALID","ERROR","WARN",
+                                             "INFO","DEBUG"};
+        syslog(map_syslog_priority(curLevel), "zookeeper[%s@%s@%d] %s",
+               sysDbgLevelStr[curLevel], funcName, line, message);
+        return;
+    }
+
+#ifndef THREADED
+    fprintf(zoo_get_log_stream(), "%s:%ld:%s@%s@%d: %s\n", time, (long)pid,
+            dbgLevelStr[curLevel],funcName,line,message);
+#else
+    #ifdef WIN32
+        tid = (unsigned long int)(pthread_self().thread_id);
+    #else
+        tid = (unsigned long int)(pthread_self());
+    #endif
+
+    fprintf(zoo_get_log_stream(), "%s:%ld(0x%lx):%s@%s@%d: %s\n", time, (long)pid, tid,
+            dbgLevelStr[curLevel], funcName, line, message);
+#endif
+    fflush(zoo_get_log_stream());
+}
+
+const char* format_log_message(const char* format,...)
+{
+    va_list va;
+    char* buf=get_format_log_buffer();
+    if(!buf)
+        return "format_log_message: Unable to allocate memory buffer";
+
+    va_start(va,format);
+    vsnprintf(buf, FORMAT_LOG_BUF_SIZE-1,format,va);
+    va_end(va);
+    return buf;
 }
 
 void zoo_set_debug_level(ZooLogLevel level)


### PR DESCRIPTION
arcus-c-client 에서 사용하는 ZooKeeper C library의 ZOO_LOG macro의
backward compatibility 를 지원하기 위한 수정 PR 입니다.

- 기존에 로그를 출력하는 함수인 log_message()의 argument가 달라지면서
기존 형식의 zoo_log_message() 함수를 제공하도록 했습니다.
- ZK C library와 arcus-c-client가 같은 방식으로 로깅하기 위해 log callback을 지원하지 않도록 변경 했습니다.

(zk_adaptor.h 파일 수정은 return type이 변경된 부분이며,
  다른 수정과 연관되지 않고 간단한 수정이라 같이 포함 시켰습니다.)

@jhpark816 
확인 요청 드립니다.