### PR TITLE
C library: change set ensemble function to use the zoo_set_servers() API

### DIFF
--- a/zookeeper-client/zookeeper-client-c/src/mt_adaptor.c
+++ b/zookeeper-client/zookeeper-client-c/src/mt_adaptor.c
@@ -44,14 +44,6 @@
 #include <sys/time.h>
 #endif
 
-int zoo_lock_new_addrs(zhandle_t *zh)
-{
-    return pthread_mutex_lock(&zh->new_addrs.lock);
-}
-int zoo_unlock_new_addrs(zhandle_t *zh)
-{
-    return pthread_mutex_unlock(&zh->new_addrs.lock);
-}
 int zoo_lock_auth(zhandle_t *zh)
 {
     return pthread_mutex_lock(&zh->auth_h.lock);
@@ -259,7 +251,6 @@ int adaptor_init(zhandle_t *zh)
     set_nonblock(adaptor_threads->self_pipe[0]);
 
     pthread_mutex_init(&zh->auth_h.lock,0);
-    pthread_mutex_init(&zh->new_addrs.lock,0);
 
     zh->adaptor_priv = adaptor_threads;
     pthread_mutex_init(&zh->to_process.lock,0);
@@ -323,7 +314,6 @@ void adaptor_destroy(zhandle_t *zh)
     pthread_mutex_destroy(&adaptor->zh_lock);
 
     pthread_mutex_destroy(&zh->auth_h.lock);
-    pthread_mutex_destroy(&zh->new_addrs.lock);
 
     close(adaptor->self_pipe[0]);
     close(adaptor->self_pipe[1]);

--- a/zookeeper-client/zookeeper-client-c/src/st_adaptor.c
+++ b/zookeeper-client/zookeeper-client-c/src/st_adaptor.c
@@ -24,14 +24,6 @@
 #include <stdlib.h>
 #include <time.h>
 
-int zoo_lock_new_addrs(zhandle_t *zh)
-{
-    return 0;
-}
-int zoo_unlock_new_addrs(zhandle_t *zh)
-{
-    return 0;
-}
 int zoo_lock_auth(zhandle_t *zh)
 {
     return 0;

--- a/zookeeper-client/zookeeper-client-c/src/zk_adaptor.h
+++ b/zookeeper-client/zookeeper-client-c/src/zk_adaptor.h
@@ -272,19 +272,6 @@ struct _zhandle {
     /** application layer ping */
     app_ping_fn app_ping;
     void *ping_context;
-
-    /* Change the ensemble list on the fly.  IO handler checks this field.
-     * See zookeeper_interest() and zookeeper_change_ensemble().
-     */
-    struct {
-        char *hostname;
-        struct sockaddr_storage *addrs;
-        int addrs_count;
-        int valid;
-#ifdef THREADED
-        pthread_mutex_t lock;
-#endif
-    } new_addrs;
 };
 
 
@@ -305,8 +292,6 @@ char* sub_string(zhandle_t *zh, const char* server_path);
 void free_duplicate_path(const char* free_path, const char* path);
 int zoo_lock_auth(zhandle_t *zh);
 int zoo_unlock_auth(zhandle_t *zh);
-int zoo_lock_new_addrs(zhandle_t *zh);
-int zoo_unlock_new_addrs(zhandle_t *zh);
 
 // ensemble reconfigure access guards
 int lock_reconfig(struct _zhandle *zh);


### PR DESCRIPTION
기존에 자체적으로 구현해 사용하던 set ensemble 함수를
zookeeper c client의 zoo_set_servers() API를 사용하도록 변경 했습니다.
변경 이유는 아래와 같습니다.

- zk handler 내부의 address 관리 구조 변경
  - 기존에는 reconfig 기능이 없었으므로, ensemble 변경에 대한 고려가 없는 형태였음
  - 변경에서는 address vector 형태로 구조가 변경되고, zoo_set_servers() API를 제공
  - 기존 set ensemble 구현을 현재 구조로 변경할 필요 없이, ZK 가 제공하는 API를 사용하는게 더 나을것으로 판단
- 향후 유지보수
  - zoo_set_servers() API를 사용함으로써, 향후 버전 교체나, 패치 사항 분석 및 반영에 유리할 것으로 판단

get ensemble 은 기존과 동일하게 동작합니다.
zk handler 내부 address를 직접 조회해 string으로 변경해 전달 및 출력합니다.

@jhpark816 
리뷰 요청 드립니다.