### PR TITLE
Changing settings for support dynamic configuration

### DIFF
--- a/bin/zkEnv.sh
+++ b/bin/zkEnv.sh
@@ -139,6 +139,9 @@ fi
 
 #echo "CLASSPATH=$CLASSPATH"
 
+# skipACL for use dynamic reconfiguration
+#export SERVER_JVMFLAGS="$SERVER_JVMFLAGS -Dzookeeper.skipACL=yes"
+
 # default heap for zookeeper server
 ZK_SERVER_HEAP="${ZK_SERVER_HEAP:-1000}"
 export SERVER_JVMFLAGS="-Xmx${ZK_SERVER_HEAP}m $SERVER_JVMFLAGS"

--- a/conf/zoo_sample.cfg
+++ b/conf/zoo_sample.cfg
@@ -10,8 +10,17 @@ syncLimit=5
 # do not use /tmp for storage, /tmp here is just 
 # example sakes.
 dataDir=/tmp/zookeeper
-# the port at which the clients will connect
-clientPort=2181
+#
+# the file path of dynamic config
+dynamicConfigFile=/tmp/zookeeper/conf/zoo.cfg.dynamic
+#
+# Enable dynamic reconfiguration
+standaloneEnabled=false
+reconfigEnabled=true
+#
+# 4 letter white list
+4lw.commands.whitelist=ruok, srvr, cons, mntr
+#
 # the maximum number of client connections.
 # increase this if you need to handle more clients
 #maxClientCnxns=60

--- a/conf/zoo_sample.cfg.dynamic
+++ b/conf/zoo_sample.cfg.dynamic
@@ -1,0 +1,7 @@
+# Information on the server
+# format
+# server.<id> = <address>:<port for sync>:<port for electing a leader>[:role];[<client port address>:]<client port>
+# example
+server.1 = 127.0.0.1:2888:3888:participant;127.0.0.1:2181
+# server.1 = 127.0.0.1:2888:3888:participant;2181
+# server.1 = 127.0.0.1:2888:3888;2181


### PR DESCRIPTION
3.5.7 arcus-zookeeper에서 dynamic reconfiguration을 지원하기 위한
설정 파일 변경 PR 입니다.

아래와 같은 내용이 추가, 변경되었습니다.
- skipACL 설정 추가
  - dynamic reconfig 명령을 사용하기 위해 ACL 설정이 필요합니다.(조회는 가능)
  - zkEnv.sh 내부에 skipACL 설정을 추가하고, 서비스 별로 ACL 설정이 필요할 수 있어 default로는 주석으로 처리해 두었습니다.
- dynamic reconfig을 위한 zoo.cfg sample 설정 변경
  - dynamicConfigFail path 설정을 포함한 설정 값들을 추가, 변경 했습니다.
  - 3.5 버전부터는 보안 문제로, 4 letter command white list 설정이 필요해 추가 했습니다.
- dynamic reconfig sample file 추가
  - ZK server ensemble 설정을 위한 format 설명 및 example 을 포함한 sample file을 추가 했습니다.

@jhpark816 
확인 요청 드립니다.