### PR TITLE
Apply ZOOKEEPER-1897 patch that ZK Shell/Cli not processing commands

### DIFF
--- a/src/java/main/org/apache/zookeeper/ZooKeeperMain.java
+++ b/src/java/main/org/apache/zookeeper/ZooKeeperMain.java
@@ -349,6 +349,9 @@ public class ZooKeeperMain {
                     executeLine(line);
                 }
             }
+        } else {
+            // Command line args non-null.  Run what was passed.
+            processCmd(cl);
         }
     }
 


### PR DESCRIPTION
ZooKeeper Client 3.4.6 버전에서 zkCli.sh의 server 명령이 실행 안되는 현상을 수정하여 반영하였습니다.

https://issues.apache.org/jira/browse/ZOOKEEPER-1897
https://github.com/apache/zookeeper/commit/46aa00b7d5ec97018ead3d2fec6b8ba5500c629b