### PR TITLE
add ARCUS patch to arcus-zookeeper 3.5.9

### DIFF
--- a/README-ZK.md
+++ b/README-ZK.md
@@ -1,0 +1,45 @@
+# Apache ZooKeeper
+![alt text](https://zookeeper.apache.org/images/zookeeper_small.gif "ZooKeeper")
+
+For the latest information about Apache ZooKeeper, please visit our website at:
+
+   http://zookeeper.apache.org/
+
+and our wiki, at:
+
+   https://cwiki.apache.org/confluence/display/ZOOKEEPER
+
+## Packaging/release artifacts
+
+Either downloaded from https://zookeeper.apache.org/releases.html or
+found in zookeeper-assembly/target directory after building the project with maven.
+
+    apache-zookeeper-[version].tar.gz
+
+        Contains all the source files which can be built by running:
+        mvn clean install
+
+        To generate an aggregated apidocs for zookeeper-server and zookeeper-jute:
+        mvn javadoc:aggregate
+        (generated files will be at target/site/apidocs)
+
+    apache-zookeeper-[version]-bin.tar.gz
+
+        Contains all the jar files required to run ZooKeeper
+        Full documentation can also be found in the docs folder
+
+As of version 3.5.5, the parent, zookeeper and zookeeper-jute artifacts
+are deployed to the central repository after the release
+is voted on and approved by the Apache ZooKeeper PMC:
+
+  https://repo1.maven.org/maven2/org/apache/zookeeper/zookeeper/
+
+## Java 8
+
+If you are going to compile with Java 1.8, you should use a
+recent release at u211 or above.
+
+## Contributing
+We always welcome new contributors to the project! See [How to Contribute](https://cwiki.apache.org/confluence/display/ZOOKEEPER/HowToContribute) for details on how to submit patch through pull request and our contribution workflow.
+
+

--- a/README.md
+++ b/README.md
@@ -1,45 +1,39 @@
-# Apache ZooKeeper
-![alt text](https://zookeeper.apache.org/images/zookeeper_small.gif "ZooKeeper")
+This is a branch off of ZooKeeper release 3.5.9.  We have made some minor
+changes to the C client library (src/c).  So, we package that and distribute
+it along with arcus-memcached and arcus-c-client.  They rely on the modified library.
 
-For the latest information about Apache ZooKeeper, please visit our website at:
+Github project page:
+https://github.com/naver/arcus
 
-   http://zookeeper.apache.org/
+## Build C library on Linux
 
-and our wiki, at:
+In the top directory, run the following to generate necessary headers and
+scripts.  Then wrap the whole C library directory in a tarball and distribute
+that file.
 
-   https://cwiki.apache.org/confluence/display/ZOOKEEPER
+    ant compile_jute
+    cd zookeeper-client/zookeeper-client-c
+    autoreconf -if
 
-## Packaging/release artifacts
+Make sure to install ant, cppunit, and cppunit-devel before running the above.
+`autoreconf` generates configure script.
 
-Either downloaded from https://zookeeper.apache.org/releases.html or
-found in zookeeper-assembly/target directory after building the project with maven.
+    ./configure --prefix=/path/to/arcus-directory
+    make
+    make install
 
-    apache-zookeeper-[version].tar.gz
+## Build Server and Java library on Linux
 
-        Contains all the source files which can be built by running:
-        mvn clean install
+In the top directory, run the following to build.
 
-        To generate an aggregated apidocs for zookeeper-server and zookeeper-jute:
-        mvn javadoc:aggregate
-        (generated files will be at target/site/apidocs)
+    mvn clean install
 
-    apache-zookeeper-[version]-bin.tar.gz
+If you are going to compile with Java 1.8, you should use a recent release at u211 or above.
 
-        Contains all the jar files required to run ZooKeeper
-        Full documentation can also be found in the docs folder
+## Arcus Contributors
 
-As of version 3.5.5, the parent, zookeeper and zookeeper-jute artifacts
-are deployed to the central repository after the release
-is voted on and approved by the Apache ZooKeeper PMC:
+The following people at NAVER have contributed to the Arcus specific
+modifications to the C client library.
 
-  https://repo1.maven.org/maven2/org/apache/zookeeper/zookeeper/
-
-## Java 8
-
-If you are going to compile with Java 1.8, you should use a
-recent release at u211 or above. 
-
-## Contributing
-We always welcome new contributors to the project! See [How to Contribute](https://cwiki.apache.org/confluence/display/ZOOKEEPER/HowToContribute) for details on how to submit patch through pull request and our contribution workflow.
-
-
+Hoonmin Kim (harebox) <harebox@gmail.com>
+HyongYoub Kim

--- a/bin/zkEnv.sh
+++ b/bin/zkEnv.sh
@@ -94,7 +94,7 @@ done
 
 #make it work in the binary package
 #(use array for LIBPATH to account for spaces within wildcard expansion)
-if ls "${ZOOKEEPER_PREFIX}"/share/zookeeper/zookeeper-*.jar > /dev/null 2>&1; then 
+if ls "${ZOOKEEPER_PREFIX}"/share/zookeeper/zookeeper-*.jar > /dev/null 2>&1; then
   LIBPATH=("${ZOOKEEPER_PREFIX}"/share/zookeeper/*.jar)
 else
   #release tarball format
@@ -138,6 +138,9 @@ then
 fi
 
 #echo "CLASSPATH=$CLASSPATH"
+
+# skipACL for use dynamic reconfiguration
+#export SERVER_JVMFLAGS="$SERVER_JVMFLAGS -Dzookeeper.skipACL=yes"
 
 # default heap for zookeeper server
 ZK_SERVER_HEAP="${ZK_SERVER_HEAP:-1000}"

--- a/conf/zoo_sample.cfg
+++ b/conf/zoo_sample.cfg
@@ -10,8 +10,21 @@ syncLimit=5
 # do not use /tmp for storage, /tmp here is just 
 # example sakes.
 dataDir=/tmp/zookeeper
-# the port at which the clients will connect
-clientPort=2181
+#
+# the file path of dynamic config
+dynamicConfigFile=/tmp/zookeeper/conf/zoo.cfg.dynamic
+#
+# ZK recommends setting this flag to false.
+# By default it is set to true for backward compatibility, but ZK will deprecate it in the future.
+# https://zookeeper.apache.org/doc/r3.5.3-beta/zookeeperReconfig.html#sc_reconfig_standaloneEnabled
+standaloneEnabled=false
+#
+# Enable dynamic reconfiguration
+reconfigEnabled=true
+#
+# 4 letter white list
+4lw.commands.whitelist=*
+#
 # the maximum number of client connections.
 # increase this if you need to handle more clients
 #maxClientCnxns=60

--- a/conf/zoo_sample.cfg.dynamic
+++ b/conf/zoo_sample.cfg.dynamic
@@ -1,0 +1,7 @@
++# Information on the server
++# format
++# server.<id> = <address>:<port for sync>:<port for electing a leader>[:role];[<client port address>:]<client port>
++# example
++server.1 = 127.0.0.1:2888:3888:participant;127.0.0.1:2181
++# server.1 = 127.0.0.1:2888:3888:participant;2181
++# server.1 = 127.0.0.1:2888:3888;2181

--- a/zookeeper-client/zookeeper-client-c/include/zookeeper.h
+++ b/zookeeper-client/zookeeper-client-c/include/zookeeper.h
@@ -42,6 +42,7 @@
 
 #define ARCUS_SHORT_CONNECT_TIMEOUT
 #define ARCUS_ZK_SYSLOG
+#define ARCUS_ZK_API
 
 /**
  * \file zookeeper.h
@@ -2298,6 +2299,37 @@ ZOOAPI int zoo_multi(zhandle_t *zh, int count, const zoo_op_t *ops, zoo_op_resul
  */
 ZOOAPI int zoo_remove_watches(zhandle_t *zh, const char *path,
         ZooWatcherType wtype, watcher_fn watcher, void *watcherCtx, int local);
+
+#ifdef ARCUS_ZK_API
+/**
+ * \brief change the ensemble address on the fly.
+ *
+ * Use this function to change the ensemble list after the initialization and while
+ * the ZooKeeper client is running.
+ * \param host comma separated host:port pairs, each corresponding to a zk
+ *   server. e.g. "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002"
+ * \return the return code for the function call.
+ * ZOK operation completed successfully
+ * ZBADARGUMENTS invalid input parameters
+ * ZSYSTEMERROR a system error occured
+ */
+ZOOAPI int zookeeper_change_ensemble(zhandle_t *zh, const char *host);
+
+/**
+ * \brief get the ensemble address in string format.
+ *
+ * Upon success, dst contains a null-terminated string, showing
+ * the IP addresses of the server in the ensemble.
+ *
+ * \param dst the caller provided buffer.
+ * \param size the size of dst in bytes.
+ * \return the return code for the function call.
+ * ZOK operation completed successfully
+ * ZBADARGUMENTS invalid input parameters
+ * ZSYSTEMERROR a system error occured
+ */
+ZOOAPI int zookeeper_get_ensemble_string(zhandle_t *zh, char *dst, int size);
+#endif
 #endif
 #ifdef __cplusplus
 }

--- a/zookeeper-client/zookeeper-client-c/include/zookeeper.h
+++ b/zookeeper-client/zookeeper-client-c/include/zookeeper.h
@@ -40,6 +40,8 @@
 #include "recordio.h"
 #include "zookeeper.jute.h"
 
+#define ARCUS_SHORT_CONNECT_TIMEOUT
+
 /**
  * \file zookeeper.h
  * \brief ZooKeeper functions and definitions.

--- a/zookeeper-client/zookeeper-client-c/include/zookeeper.h
+++ b/zookeeper-client/zookeeper-client-c/include/zookeeper.h
@@ -41,6 +41,7 @@
 #include "zookeeper.jute.h"
 
 #define ARCUS_SHORT_CONNECT_TIMEOUT
+#define ARCUS_ZK_SYSLOG
 
 /**
  * \file zookeeper.h
@@ -1587,6 +1588,16 @@ ZOOAPI log_callback_fn zoo_get_log_callback(const zhandle_t *zh);
  * it needs to be thread-safe.
  */
 ZOOAPI void zoo_set_log_callback(zhandle_t *zh, log_callback_fn callback);
+
+#ifdef ARCUS_ZK_SYSLOG
+/**
+ * \brief sets the stream to be forwarded to syslogd for logging
+ *
+ * If passed a non-zero value for enable, will make the log to be forwarded to
+ * syslogd.
+ */
+ZOOAPI void zoo_forward_logs_to_syslog(const char *name, int enable);
+#endif
 
 /**
  * \brief enable/disable quorum endpoint order randomization

--- a/zookeeper-client/zookeeper-client-c/include/zookeeper_log.h
+++ b/zookeeper-client/zookeeper-client-c/include/zookeeper_log.h
@@ -24,6 +24,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+#define ARCUS_C_CLIENT_LOG
 
 extern ZOOAPI ZooLogLevel logLevel;
 #define LOGCALLBACK(_zh) zoo_get_log_callback(_zh)
@@ -43,6 +44,22 @@ ZOOAPI void log_message(log_callback_fn callback, ZooLogLevel curLevel,
 
 FILE* zoo_get_log_stream();
 
+#ifdef ARCUS_C_CLIENT_LOG
+/* ZOO_LOG macros are used in arcus-c-client */
+#define ZOO_LOG_ERROR(x) if(logLevel>=ZOO_LOG_LEVEL_ERROR) \
+    zoo_log_message(ZOO_LOG_LEVEL_ERROR, __LINE__, __func__, format_log_message x)
+#define ZOO_LOG_WARN(x) if(logLevel>=ZOO_LOG_LEVEL_WARN) \
+    zoo_log_message(ZOO_LOG_LEVEL_WARN, __LINE__, __func__, format_log_message x)
+#define ZOO_LOG_INFO(x) if(logLevel>=ZOO_LOG_LEVEL_INFO) \
+    zoo_log_message(ZOO_LOG_LEVEL_INFO, __LINE__, __func__, format_log_message x)
+#define ZOO_LOG_DEBUG(x) if(logLevel==ZOO_LOG_LEVEL_DEBUG) \
+    zoo_log_message(ZOO_LOG_LEVEL_DEBUG, __LINE__, __func__, format_log_message x)
+
+ZOOAPI void zoo_log_message(ZooLogLevel curLevel, int line, const char* funcName,
+    const char* message);
+
+ZOOAPI const char* format_log_message(const char* format,...);
+#endif
 #ifdef __cplusplus
 }
 #endif

--- a/zookeeper-client/zookeeper-client-c/include/zookeeper_version.h
+++ b/zookeeper-client/zookeeper-client-c/include/zookeeper_version.h
@@ -25,6 +25,7 @@ extern "C" {
 #define ZOO_MAJOR_VERSION 3
 #define ZOO_MINOR_VERSION 5
 #define ZOO_PATCH_VERSION 9
+#define ZOO_INHOUSE_VERSION 1
 
 #ifdef __cplusplus
 }

--- a/zookeeper-client/zookeeper-client-c/src/cli.c
+++ b/zookeeper-client/zookeeper-client-c/src/cli.c
@@ -730,11 +730,20 @@ int main(int argc, char **argv) {
         fprintf(stderr,
                 "USAGE %s zookeeper_host_list [clientid_file|cmd:(ls|ls2|create|create2|od|...)]\n", 
                 argv[0]);
+#if ZOO_INHOUSE_PATCH_VERSION > 0
+        fprintf(stderr,
+                "Version: ZooKeeper cli (c client) version %d.%d.%d-p%d\n",
+                ZOO_MAJOR_VERSION,
+                ZOO_MINOR_VERSION,
+                ZOO_PATCH_VERSION,
+                ZOO_INHOUSE_PATCH_VERSION);
+#else
         fprintf(stderr,
                 "Version: ZooKeeper cli (c client) version %d.%d.%d\n", 
                 ZOO_MAJOR_VERSION,
                 ZOO_MINOR_VERSION,
                 ZOO_PATCH_VERSION);
+#endif
         return 2;
     }
     if (argc > 2) {

--- a/zookeeper-client/zookeeper-client-c/src/zk_log.c
+++ b/zookeeper-client/zookeeper-client-c/src/zk_log.c
@@ -189,6 +189,66 @@ void log_message(log_callback_fn callback, ZooLogLevel curLevel,
     }
 }
 
+#ifdef ARCUS_C_CLIENT_LOG
+void zoo_log_message(ZooLogLevel curLevel,int line,const char* funcName,
+    const char* message)
+{
+    static const char* dbgLevelStr[]={"ZOO_INVALID","ZOO_ERROR","ZOO_WARN",
+            "ZOO_INFO","ZOO_DEBUG"};
+    static pid_t pid=0;
+#ifdef THREADED
+    unsigned long int tid = 0;
+#endif
+#ifdef WIN32
+    char timebuf [TIME_NOW_BUF_SIZE];
+    const char* time = time_now(timebuf);
+#else
+    const char* time = time_now(get_time_buffer());
+#endif
+
+    if(pid==0)
+    {
+        pid=getpid();
+    }
+
+    if(enableSyslog && logLevel >= curLevel) {
+        static const char* sysDbgLevelStr[]={"INVALID","ERROR","WARN",
+                                             "INFO","DEBUG"};
+        syslog(map_syslog_priority(curLevel), "zookeeper[%s@%s@%d] %s",
+               sysDbgLevelStr[curLevel], funcName, line, message);
+        return;
+    }
+
+#ifndef THREADED
+    fprintf(zoo_get_log_stream(), "%s:%ld:%s@%s@%d: %s\n", time, (long)pid,
+            dbgLevelStr[curLevel],funcName,line,message);
+#else
+    #ifdef WIN32
+        tid = (unsigned long int)(pthread_self().thread_id);
+    #else
+        tid = (unsigned long int)(pthread_self());
+    #endif
+
+    fprintf(zoo_get_log_stream(), "%s:%ld(0x%lx):%s@%s@%d: %s\n", time, (long)pid, tid,
+            dbgLevelStr[curLevel], funcName, line, message);
+#endif
+    fflush(zoo_get_log_stream());
+}
+
+const char* format_log_message(const char* format,...)
+{
+    va_list va;
+    char* buf=get_format_log_buffer();
+    if(!buf)
+        return "format_log_message: Unable to allocate memory buffer";
+
+    va_start(va,format);
+    vsnprintf(buf, FORMAT_LOG_BUF_SIZE-1,format,va);
+    va_end(va);
+    return buf;
+}
+#endif
+
 void zoo_set_debug_level(ZooLogLevel level)
 {
     if(level==0){


### PR DESCRIPTION
arcus-3.5.8 의 커밋 리스트입니다. https://github.com/naver/arcus-zookeeper/commits/arcus-3.5.8

a. FIX: follow C90 standard 
b. FIX: add all four letter words to whitelist 
c. Changing settings for support dynamic configuration
d. Add README.md   
e. C library: change set ensemble function to use the zoo_set_servers() API
f. C library: support ZOO_LOG macros for backward compatibility
g. C library: change version from 3.4.5 to 3.4.5-p1 
h. C library: add functions to set, get ensemble list after init 
i. C library: add zoo_forward_logs_to_syslog 
j. C library: use a short connect timeout 
k. C library: prefix LOG macros to avoid name conflicts 
l. C library: add L7 (application layer) ping support (반영 제외)

반영할 arcus-3.5.9 의 커밋 리스트입니다.

1. Add README.md  (d)
2. C library: change version from 3.5.9 to 3.5.9-p1 (g)
3. Changing settings for support dynamic configuration (b + c)
4. C library: add functions to set, get ensemble list after init  (a + e + h)
5. C library: add zoo_forward_logs_to_syslog (i)
6. C library: use a short connect timeout (j + f)
7. C library: prefix LOG macros to avoid name conflicts (k + f) 

커밋 별로 정의한 코드태그입니다.
zookeeper_log.h 
- ARCUS_C_CLIENT_LOG : 7

zookeeper.h 
- ARCUS_SHORT_CONNECT_TIMEOUT : 6
- ARCUS_ZK_API : 4
- ARCUS_ZK_SYSLOG : 5

테스트 사항입니다.
- 컴파일, 빌드
- ARCUS cluster (캐시노드+클라이언트+주키퍼) 구성 후 부하 요청
- zkensemble get, set 명령 수행 확인.