### PR TITLE
C library: change version from 3.5.9 to 3.5.9-p1 (FIX)

### DIFF
--- a/zookeeper-client/zookeeper-client-c/src/cli.c
+++ b/zookeeper-client/zookeeper-client-c/src/cli.c
@@ -730,7 +730,7 @@ int main(int argc, char **argv) {
         fprintf(stderr,
                 "USAGE %s zookeeper_host_list [clientid_file|cmd:(ls|ls2|create|create2|od|...)]\n", 
                 argv[0]);
-#if ZOO_INHOUSE_PATCH_VERSION > 0
+#if ZOO_INHOUSE_VERSION > 0
         fprintf(stderr,
                 "Version: ZooKeeper cli (c client) version %d.%d.%d-p%d\n",
                 ZOO_MAJOR_VERSION,


### PR DESCRIPTION
https://github.com/naver/arcus-zookeeper/commit/daba9c71f6b1bd764b439a914172a298a798be1c 커밋에 버그가 있어서 수정하였습니다.
