### PR TITLE
DOC: added automake dependency in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ https://github.com/naver/arcus
 
 ## Build C library on Linux
 
+dependency requirements:
+
+    automake 1.12 or higher version // for using serial-tests option (https://issues.apache.org/jira/browse/ZOOKEEPER-1893)
+
 In the top directory, run the following to generate necessary headers and
 scripts.  Then wrap the whole C library directory in a tarball and distribute
 that file.


### PR DESCRIPTION
automake 버전 의존성 사항을 README.md 에 추가하였습니다.
코드 적용 모습 : https://github.com/suhwanjang/arcus-zookeeper/tree/arcus-3.5.9