### PR TITLE
DOC: added C build dependency in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ https://github.com/naver/arcus
 dependency requirements:
 
     automake 1.12 or higher version // for using serial-tests option (https://issues.apache.org/jira/browse/ZOOKEEPER-1893)
+    autoconf 2.59 or higher version
+    cppunit 1.11 or higher version
 
 In the top directory, run the following to generate necessary headers and
 scripts.  Then wrap the whole C library directory in a tarball and distribute
@@ -33,6 +35,10 @@ In the top directory, run the following to build.
     mvn clean install
 
 If you are going to compile with Java 1.8, you should use a recent release at u211 or above.
+
+## Build Troubleshooting
+
+[build-faq](https://github.com/naver/arcus/blob/master/docs/build-faq.md) may help you fix the build problems.
 
 ## Arcus Contributors
 


### PR DESCRIPTION
zookeeper C README(https://github.com/SuhwanJang/arcus-zookeeper/blob/arcus-3.5.9/zookeeper-client/zookeeper-client-c/README) 에서 안내하는 C build dependency 와 build-faq 문서 링크를 README.md 에 추가하였습니다.

autoconf 2.59 or higher version :
```
3) change directory to zookeeper-client/zookeeper-client-c and do a "autoreconf -if" 
to bootstrap autoconf, automake and libtool. Please make sure you have autoconf version 2.59 or greater installed.
```

cppunit 1.11 or higher version :
```
 5) do a "make" or "make install" to build the libraries and install them.
    Alternatively, you can also build and run a unit test suite (and
    you probably should).  Please make sure you have cppunit-1.10.x or
    higher installed before you execute step 4.
```
- 안전하게 1.10.x 보다 상위 버전으로 명시하였습니다. CentOS 6, 7 에서 설치되는 cppunit version 은 1.12.

PR 적용 문서 : https://github.com/SuhwanJang/arcus-zookeeper/tree/arcus-3.5.9