### PR TITLE
FEATURE: Add release flag to show the version

### DIFF
--- a/zookeeper-client/zookeeper-client-c/Makefile.am
+++ b/zookeeper-client/zookeeper-client-c/Makefile.am
@@ -16,7 +16,7 @@ if ENABLEGCOV
   AM_LDFLAGS = -lgcov
 endif
 
-LIB_LDFLAGS = -no-undefined -version-info 2 $(SOLARIS_LIB_LDFLAGS)
+LIB_LDFLAGS = -no-undefined -release $(PACKAGE_VERSION) -version-info 2 $(SOLARIS_LIB_LDFLAGS)
 
 pkginclude_HEADERS = include/zookeeper.h include/zookeeper_version.h include/zookeeper_log.h include/proto.h include/recordio.h generated/zookeeper.jute.h
 EXTRA_DIST=LICENSE


### PR DESCRIPTION
- jam2in/arcus-works#364

`Makefile.am`의 LDFLAGS에 `-release` 플래그를 추가합니다.
변경 이후 make install 결과물은 아래와 같습니다.

```
ls -R
.:
bin  include  lib

./bin:
cli_mt  cli_st  load_gen

./include:
zookeeper

./include/zookeeper:
proto.h  recordio.h  zookeeper.h  zookeeper.jute.h  zookeeper_log.h  zookeeper_version.h

./lib:
libzookeeper_mt-3.5.9.so.2  libzookeeper_mt-3.5.9.so.2.0.0  libzookeeper_mt.a  libzookeeper_mt.la  libzookeeper_mt.so  
libzookeeper_st-3.5.9.so.2  libzookeeper_st-3.5.9.so.2.0.0  libzookeeper_st.a  libzookeeper_st.la  libzookeeper_st.so
```
