### PR TITLE
INTERNAL: Change name of version API on C client

### DIFF
--- a/zookeeper-client/zookeeper-client-c/include/zookeeper.h
+++ b/zookeeper-client/zookeeper-client-c/include/zookeeper.h
@@ -346,11 +346,15 @@ typedef struct zoo_op {
 
 #ifdef ARCUS_ZK_API
 /**
-   Get the Zookeeper C client version.
-
-   @return a string containing the version number of Zookeeper C client
- */
-char *zoo_get_version(void);
+  * \brief return the zookeeper <MAJOR>.<MINOR>.<PATCH>-p<INHOUSE> version as a string
+  *
+  * This method allows a calling program to determine at runtime if the
+  * version of the dynamically loaded zookeeper library is the same as
+  * the version of the library when the calling program was compiled.
+  *
+  * \return a string "<MAJOR>.<MINOR>.<PATCH>-p<INHOUSE>"
+  */
+ZOOAPI const char* zoo_version_str();
 #endif
 
 /**

--- a/zookeeper-client/zookeeper-client-c/include/zookeeper_version.h
+++ b/zookeeper-client/zookeeper-client-c/include/zookeeper_version.h
@@ -27,6 +27,8 @@ extern "C" {
 #define ZOO_PATCH_VERSION 9
 #define ZOO_INHOUSE_VERSION 2
 
+#define ZOO_VERSION "3.5.9-p2"
+
 #ifdef __cplusplus
 }
 #endif

--- a/zookeeper-client/zookeeper-client-c/src/zookeeper.c
+++ b/zookeeper-client/zookeeper-client-c/src/zookeeper.c
@@ -4353,10 +4353,13 @@ done:
 }
 
 #ifdef ARCUS_ZK_API
-char *zoo_get_version(void)
-{
-    return PACKAGE_VERSION;
-}
+/**
+  * Return string of "<MAJOR>.<MINOR>.<PATCH>-p<INHOUSE>"
+  */
+ const char *zoo_version_str()
+ {
+     return ZOO_VERSION;
+ }
 #endif
 
 void zoo_create_op_init(zoo_op_t *op, const char *path, const char *value,


### PR DESCRIPTION
- jam2in/arcus-works#364

ZooKeeper C client의 버전명을 리턴하는 함수를 apache/zookeeper와 유사한 구조를 갖도록 변경합니다.

@Yeoncheol-Kim