### PR TITLE
INTERNAL: Add AdminServer property in zoo_sample.cfg

### DIFF
--- a/conf/zoo_sample.cfg
+++ b/conf/zoo_sample.cfg
@@ -1,4 +1,4 @@
-# Last update: 2024-01-24
+# Last update: 2024-04-15
 #
 # The number of milliseconds of each tick
 tickTime=2000
@@ -50,3 +50,7 @@ autopurge.purgeInterval=24
 # ZooKeeper will throttle clients so that there is no more than globalOutstandingLimit outstanding requests in the system.
 # The default limit is 1,000.  For now, follow the default by annotating the below setting.
 #globalOutstandingLimit=1000
+#
+# AdminServer(http) (since 3.5.0)
+#admin.enableServer=true
+#admin.serverPort=8080


### PR DESCRIPTION
### 🔗 Related Issue
- jam2in/arcus-works#370

### ⌨️ What I did
- `zoo_sample.cfg`를 기반으로 `zoo.cfg`를 작성하는 경우 http를 통해 서버 명령을 입력받는 AdminServer가 비활성화됩니다.
